### PR TITLE
Weighted KMeans, TICA+VAMP, and some performance improvements

### DIFF
--- a/msm_we/msm_we.py
+++ b/msm_we/msm_we.py
@@ -3581,21 +3581,33 @@ class modelWE:
             with concurrent.futures.ProcessPoolExecutor(
                 max_workers=1, mp_context=mp.get_context("fork")
             ) as executor:
-                (
-                    stratified_clusters,
-                    extra_iters_used,
-                    filled_bins,
-                    unfilled_bins,
-                ) = executor.submit(
-                    self.do_stratified_clustering,
-                    [
-                        self,
+
+                try:
+                    (
                         stratified_clusters,
-                        iters_to_use[iter_idx:],
-                        self.processCoordinates,
-                        ignored_bins,
-                    ],
-                ).result()
+                        extra_iters_used,
+                        filled_bins,
+                        unfilled_bins,
+                    ) = executor.submit(
+                        self.do_stratified_clustering,
+                        [
+                            self,
+                            stratified_clusters,
+                            iters_to_use[iter_idx:],
+                            self.processCoordinates,
+                            ignored_bins,
+                        ],
+                    ).result()
+
+                except AssertionError as e:
+                    # If we succeeded in passing this loop at least once, then all our bins have *something* in them.
+                    # TODO: The better way to handle this is as long as you've clustered something, you can do piecemeal
+                    #   (i.e. don't have to populate every bin after the first time)
+                    if iter_idx == 0:
+                        log.info(f"Failed with {iter_idx} + {extra_iters_used} vs len {(len(iters_to_use))}")
+                        raise e
+                    else:
+                        log.info("Clustering couldn't use last iteration, not all bins filled.")
 
                 all_filled_bins.update(filled_bins)
                 all_unfilled_bins.update(unfilled_bins)

--- a/msm_we/msm_we.py
+++ b/msm_we/msm_we.py
@@ -18,6 +18,7 @@ import scipy.sparse as sparse
 from sklearn.decomposition import IncrementalPCA as iPCA
 from sklearn.cluster import KMeans as kmeans
 from sklearn.cluster import MiniBatchKMeans as mini_kmeans
+from deeptime.decomposition import TICA, VAMP
 
 import logging
 from rich.logging import RichHandler

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ requirements = [
     "h5py>=3.1",
     "tqdm",
     "rich",
-    "toml"
+    "toml",
+    "matplotlib"
 ]
 
 setup_requirements = [


### PR DESCRIPTION
Those performance improvements should really be a separate PR, but as they say in computer vision, YOLO

This PR includes implementations of:
- Weighted KMeans, using segment weights (enabled if `model.use_weights_in_clustering == True`)
- Weighted PCA (weights enabled if `use_weights=True`  is passed to `modelWE.dimReduce()`
- TICA (Weights optionally enabled as for PCA)
- VAMP (Weights not yet supported)

Additionally, some improvements to caching discretized trajectories were implemented, along with passing sparser model objects to various worker processes to avoid sending tons of unnecessary data.