### PR TITLE
Cache pcoord on restart

### DIFF
--- a/msm_we/_hamsm/_clustering.py
+++ b/msm_we/_hamsm/_clustering.py
@@ -1393,6 +1393,7 @@ class ClusteringMixin:
         # Move this elsewhere, WE segment weights are useful to have outside of this
         all_seg_weights = np.full(int(sum(self.numSegments)), fill_value=None)
 
+        pcoord_cache = None
         if build_pcoord_cache:
             pcoord_cache = {}
 

--- a/msm_we/_hamsm/_data.py
+++ b/msm_we/_hamsm/_data.py
@@ -869,6 +869,7 @@ class DataMixin:
                         self.pcoord_shape_warned = True
 
                     # Iterate over segments in this dataset
+                    # TODO: This loop is probably really inefficient?
                     for seg_idx in range(n_segs_in_file):
                         # if np.sum(pcoord[seg_idx,self.pcoord_len-1,:])==0.0:
                         # # intentionally using this to write in dummy pcoords,

--- a/msm_we/westpa_plugins/restart_driver.py
+++ b/msm_we/westpa_plugins/restart_driver.py
@@ -25,6 +25,7 @@ from rich.logging import RichHandler
 from matplotlib import pyplot as plt
 
 from copy import deepcopy
+import time
 import re
 
 EPS = np.finfo(np.float64).eps
@@ -467,34 +468,31 @@ class RestartDriver(HAMSMDriver):
 
     def init_we(self, initialization_state, pcoord_cache):
 
-        import time
-        import re
         start_time = time.perf_counter()
 
         original_get_pcoord = None
 
         if pcoord_cache is not None:
 
-            log.critical("Enabling pcoord cache for new WE run initialization")
-
-            # TODO: Use cached pcoords
+            log.info("Enabling pcoord cache for new WE run initialization")
             propagator = westpa.rc.propagator
             original_get_pcoord = propagator.get_pcoord
 
-            """
-            For the cached pcoords, I'll be getting a bunch of istate/bstate/sstates, and I need to 
-                map them to some cached pcoord values.
-                
-            At this point, my start states are just basis states (not initial states)... Because of that,
-            in order to determine if it's a start state or an "actual" basis state, we can check if the label\
-            matches the bX_sY format we use below.
-            
-            This is a little janky and fragile, and other possible ways to check if a BasisState was generate from a
-            start state could be
-            
-            """
             def get_cached_pcoord(state):
-                # from westpa.core.states import InitialState
+                """
+                For the cached pcoords, I'll be getting a bunch of istate/bstate/sstates, and I need to
+                    map them to some cached pcoord values.
+
+                At this point, my start states are just basis states (not initial states)... Because of that,
+                in order to determine if it's a start state or an "actual" basis state, we can check if the label\
+                matches the bX_sY format we use below.
+
+                This is a little janky and fragile.
+
+                This function is defined inline because it needs to take only the state argument, and have access to
+                the cache.
+                TODO: That could also be done by just adding those as attributes to the state.
+                """
 
                 # If it IS a start-state, then retrieve the pcoord from the cache
                 label = state.label
@@ -502,14 +500,7 @@ class RestartDriver(HAMSMDriver):
                 template = re.compile(r'^b(\d+)_s(\d+)$')
                 is_start_state = template.match(label)
 
-                # if type(state) is InitialState and state.type == InitialState.ISTATE_TYPE_START:
                 if is_start_state:
-                    try:
-                        auxref = state.auxref
-                    except AttributeError as e:
-
-                        log.critical(f"Failed cache for state {state} with vars {vars(state)}")
-                        raise e
 
                     # This is NOT the "segment index" as WESTPA describes it -- it's the index of this structure
                     #   among structures in this cluster.
@@ -517,21 +508,11 @@ class RestartDriver(HAMSMDriver):
                     cluster_idx = int(cluster_idx)
                     cluster_seg_idx = int(cluster_seg_idx)
 
-                    # log.critical("Getting pcoord from cache")
-                    try:
-                        state.pcoord = pcoord_cache[int(cluster_idx)][int(cluster_seg_idx)]
-                    except KeyError as e:
-                        log.critical(f'Failed pcoord lookup for cluster {cluster_idx} seg {cluster_seg_idx} with '
-                                     f'label {label}')
-                        log.critical(f"Cache is defined for segs {list(pcoord_cache[int(cluster_idx)].keys())}")
-                        raise e
+                    state.pcoord = pcoord_cache[int(cluster_idx)][int(cluster_seg_idx)]
 
                 # If it's not a start state, then apply the normal pcoord calculation
                 else:
-                    log.critical(f"Getting pcoord the original way, because {type(state)} and has attribute? "
-                                 f"{hasattr(state, 'basis_auxref')}")
-                    log.critical(vars(state))
-
+                    log.debug(f"Not using cache for state {state}")
                     original_get_pcoord(state)
 
             propagator.get_pcoord = get_cached_pcoord
@@ -541,13 +522,11 @@ class RestartDriver(HAMSMDriver):
             shotgun=False,
         )
 
-        # TODO: Restore original pcoord calculation
         if pcoord_cache is not None:
             propagator.get_pcoord = original_get_pcoord
 
         end_time = time.perf_counter()
-        log.critical(f"Runtime of w_init was {end_time - start_time:.2f} seconds")
-
+        log.debug(f"Runtime of w_init was {end_time - start_time:.2f} seconds")
 
     def prepare_new_we(self):
         """

--- a/msm_we/westpa_plugins/restart_driver.py
+++ b/msm_we/westpa_plugins/restart_driver.py
@@ -231,6 +231,7 @@ class RestartDriver(HAMSMDriver):
         )
 
         self.pcoord_cache = None
+        self.model = None
 
     def get_original_bins(self):
         """
@@ -843,7 +844,6 @@ class RestartDriver(HAMSMDriver):
         # Wipe out the old pcoord cache
         self.pcoord_cache = None
 
-        # TODO: Why can't I retrieve this off self.data_manager?
         self.model = self.construct_hamsm()
         model = self.model
         westpa.rc.pstatus(f"Getting built haMSM from {self.data_manager}")

--- a/msm_we/westpa_plugins/restart_driver.py
+++ b/msm_we/westpa_plugins/restart_driver.py
@@ -698,11 +698,7 @@ class RestartDriver(HAMSMDriver):
                 )
 
                 self.init_we(initialization_state, self.pcoord_cache)
-                # w_init.initialize(
-                #     **initialization_state,
-                #     shotgun=False,
-                # )
-                #
+
                 with open(self.restart_file, "w") as fp:
                     json.dump(restart_state, fp)
 
@@ -863,6 +859,7 @@ class RestartDriver(HAMSMDriver):
         # Obtain cluster-structures
         log.debug("Obtaining cluster-structures")
         model.update_cluster_structures(build_pcoord_cache=self.cache_pcoords)
+        self.pcoord_cache = deepcopy(model.pcoord_cache)
 
         # TODO: Do this with pathlib
         struct_directory = f"{restart_directory}/structs"
@@ -1055,7 +1052,7 @@ class RestartDriver(HAMSMDriver):
             #     f"\n\t pSS (+target, no basis) sum: {sum(model.pSS[:-2]) + model.pSS[-1]}"
             # )
 
-        ### Start the new simulation
+        # ## Start the new simulation
 
         bstates_str = ""
         for original_bstate in original_bstates:
@@ -1147,9 +1144,7 @@ class RestartDriver(HAMSMDriver):
         )
         log.critical(f"Calling init_we with model {model}")
 
-        self.pcoord_cache = deepcopy(model.pcoord_cache)
         self.init_we(initialization_state, self.pcoord_cache)
-        # w_init.initialize(**initialization_state, shotgun=False)
 
         log.info("New WE run ready!")
         westpa.rc.pstatus(

--- a/msm_we/westpa_plugins/restart_driver.py
+++ b/msm_we/westpa_plugins/restart_driver.py
@@ -184,6 +184,10 @@ class RestartDriver(HAMSMDriver):
         self.n_restarts = plugin_config.get("n_restarts", -1)
         self.n_runs = plugin_config.get("n_runs", 1)
 
+        # May want to be able to disable this, if it causes issues with recalculating new pcoords
+        #   (i.e. during optimization)
+        self.cache_pcoords = plugin_config.get("cache_pcoords", True)
+
         # .get() might return this as a bool anyways, but be safe
         self.debug = bool(plugin_config.get("debug", False))
         if self.debug:
@@ -879,7 +883,7 @@ class RestartDriver(HAMSMDriver):
 
         # Obtain cluster-structures
         log.debug("Obtaining cluster-structures")
-        model.update_cluster_structures(build_pcoord_cache=True)
+        model.update_cluster_structures(build_pcoord_cache=self.cache_pcoords)
 
         # TODO: Do this with pathlib
         struct_directory = f"{restart_directory}/structs"


### PR DESCRIPTION
When restarting, pcoords must be re-calculated for every single start-state. This becomes extremely slow for large numbers of states and expensive pcoord calculations. 

Furthermore, it's unnecessary, because we already have the pcoords. This PR includes a change where `modelWE.update_cluster_structures(build_pcoord_cache=True)` will produce a dictionary mapping each `[cluster idx][seg idx]` to its pcoord.

When the restart plugin initializes a new run, it will temporarily overload the propagator's `get_pcoord` to use this cache, then restore the original behavior after initialization is complete.

## TODO:
- [ ] It may be more efficient to just read pcoords directly from `west.h5`, instead of building this cache and tracking them separately. 
- [ ] Maybe the cache should be written to disk
- [x] Verify that this still works after restartXX/Run1