### PR TITLE
Restart bstate weighting

### DIFF
--- a/.github/workflows/mamba-test.yml
+++ b/.github/workflows/mamba-test.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+env:
+    OMP_NUM_THREADS: 1
+
 on:
   push:
     branches:

--- a/environment.yml
+++ b/environment.yml
@@ -26,3 +26,6 @@ dependencies:
    - ray
    - synd
    - .
+variables:
+  OMP_NUM_THREADS: 1
+  RAY_worker_register_timeout_seconds: 60

--- a/msm_we/westpa_plugins/restart_driver.py
+++ b/msm_we/westpa_plugins/restart_driver.py
@@ -1066,7 +1066,12 @@ class RestartDriver(HAMSMDriver):
 
         bstates_str = ""
         for original_bstate in original_bstates:
-            orig_bstate_prob = original_bstate.probability
+            # We crush the original basis state probabilities here -- they'll be represented in the start-states
+            #   anyways, we mostly just need to provide them for recycling.
+            # As long as their relative weights (within the set of basis states) is unaffected, recycling will work
+            #   the same after this rescaling.
+            # By doing this, we ensure that start-states will dominate probabilities during initialization.
+            orig_bstate_prob = original_bstate.probability * 1e-10
             orig_bstate_label = original_bstate.label
             orig_bstate_aux = original_bstate.auxref
 

--- a/msm_we/westpa_plugins/restart_driver.py
+++ b/msm_we/westpa_plugins/restart_driver.py
@@ -894,7 +894,7 @@ class RestartDriver(HAMSMDriver):
         # TODO: Don't explicitly write EVERY structure to disk, or this will be a nightmare for large runs.
         # However, for now, it's fine...
         log.debug("Writing structures")
-        # TODO: Include start states from previous runs
+        # TODO: Include start states from previous runs (this is done implicitly if using west.h5 from those runs)
         sstates_filename = f"{restart_directory}/startstates.txt"
         with open(sstates_filename, "w") as fp:
 
@@ -1067,10 +1067,13 @@ class RestartDriver(HAMSMDriver):
         bstates_str = ""
         for original_bstate in original_bstates:
             # We crush the original basis state probabilities here -- they'll be represented in the start-states
-            #   anyways, we mostly just need to provide them for recycling.
+            #   anyway, we mostly just need to provide them for recycling.
             # As long as their relative weights (within the set of basis states) is unaffected, recycling will work
             #   the same after this rescaling.
             # By doing this, we ensure that start-states will dominate probabilities during initialization.
+            # TODO: This is a little gross though, because if we hit the probability too much, we'll get issuers down
+            #   the line from floating point arithmetic. Maybe there's a better way to deprioritize basis-states
+            #   relative to start-states during initialization.
             orig_bstate_prob = original_bstate.probability * 1e-10
             orig_bstate_label = original_bstate.label
             orig_bstate_aux = original_bstate.auxref

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,6 @@ setup(
     tests_require=test_requirements,
     extras_require=EXTRAS_REQUIRE,
     url="https://github.com/jdrusso/msm_we",
-    version="0.1.27",
+    version="0.1.28.dev1",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,14 @@
 
 from setuptools import setup, find_packages
 
-#with open("README.rst") as readme_file:
+# with open("README.rst") as readme_file:
 #    readme = readme_file.read()
 
-#with open("HISTORY.rst") as history_file:
+# with open("HISTORY.rst") as history_file:
 #    history = history_file.read()
 
 # WESTPA-2.0 with westpa.analysis is not yet in Conda
-#requirements = ["westpa>=v2.0b5"]
+# requirements = ["westpa>=v2.0b5"]
 requirements = [
     "scikit-learn>=0.24,<1.1",
     "scipy>=1.5",
@@ -22,7 +22,8 @@ requirements = [
     "tqdm",
     "rich",
     "toml",
-    "matplotlib"
+    "matplotlib",
+    "deeptime",
 ]
 
 setup_requirements = [
@@ -55,7 +56,7 @@ setup(
     entry_points={"console_scripts": ["msm_we=msm_we.cli:main"]},
     install_requires=requirements,
     license="MIT license",
-#    long_description=readme + "\n\n" + history,
+    #    long_description=readme + "\n\n" + history,
     include_package_data=True,
     keywords="msm_we",
     name="msm_we",


### PR DESCRIPTION
## Bugfix
- includes a fix for a missing `deeptime` dependency

## New functionality
- After a restart, rescales basis-state probabilities. This ensures that start-states are selected over basis-states for restarting.
- base path to `west.h5` files for haMSM building is now explicitly set to the CWD. This helps Ray parallel workers find them, since the Ray workers may have a different working directory.
- `first_analysis_iter` is exposed now so burn-in after a restart can be omitted for haMSM building.