### PR TITLE
Detect overcorrection

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
- - numpy
+ - numpy<1.24
  - networkx
  - h5py<3.2
  - matplotlib

--- a/msm_we/_hamsm/_clustering.py
+++ b/msm_we/_hamsm/_clustering.py
@@ -1121,6 +1121,8 @@ class ClusteringMixin:
         self.indTargets = np.array([self.n_clusters + 1])
         self.nBins = self.n_clusters + 2
 
+        self.update_sorted_cluster_centers()
+
         self.cluster_mapping = {x: x for x in range(self.n_clusters + 2)}
 
         # Sanity check that cleaning worked
@@ -1589,6 +1591,10 @@ class ClusteringMixin:
         self.targetRMSD_minmax = cluster_pcoord_range[pcoord_sort_indices]
         self.targetRMSD_all = np.array(cluster_pcoord_all)[pcoord_sort_indices]
 
+        return pcoord_sort_indices
+
+    def update_sorted_cluster_centers(self):
+
         # Todo: Don't assume these will always be sorted by pcoord 0
         log.info("Note: Sorting bins, assuming that pcoord 0 is meaningful for sorting")
         bin_centers = self.targetRMSD_centers[:, 0]
@@ -1598,5 +1604,3 @@ class ClusteringMixin:
         # All centers includes target/basis
         self.all_centers = bin_centers
         self.sorted_centers = np.argsort(bin_centers)
-
-        return pcoord_sort_indices

--- a/msm_we/_hamsm/_clustering.py
+++ b/msm_we/_hamsm/_clustering.py
@@ -31,6 +31,8 @@ class ClusteringMixin:
     targetRMSD_centers = None
     targetRMSD_minmax = None
     targetRMSD_all = None
+    all_centers = None  # Includes target and basis state coordinates
+    sorted_centers = None
 
     pcoord_cache = None
     cluster_structures = None
@@ -1586,5 +1588,15 @@ class ClusteringMixin:
         self.targetRMSD_centers = cluster_pcoord_centers[pcoord_sort_indices]
         self.targetRMSD_minmax = cluster_pcoord_range[pcoord_sort_indices]
         self.targetRMSD_all = np.array(cluster_pcoord_all)[pcoord_sort_indices]
+
+        # Todo: Don't assume these will always be sorted by pcoord 0
+        log.info("Note: Sorting bins, assuming that pcoord 0 is meaningful for sorting")
+        bin_centers = self.targetRMSD_centers[:, 0]
+        bin_centers[self.indTargets] = self.target_bin_centers
+        bin_centers[self.indBasis] = self.basis_bin_centers
+
+        # All centers includes target/basis
+        self.all_centers = bin_centers
+        self.sorted_centers = np.argsort(bin_centers)
 
         return pcoord_sort_indices

--- a/msm_we/_hamsm/_plotting.py
+++ b/msm_we/_hamsm/_plotting.py
@@ -207,6 +207,35 @@ class PlottingMixin:
         ax.set_ylabel("Flux (weight/second)")
         self.print_pseudocommittor_warning()
 
+        slope = self.fit_parameters["slope"]
+        intercept = self.fit_parameters["intercept"]
+        r_value = self.fit_parameters["r_value"]
+        # Omit the first and last, because those bin centers may be weird for bins reaching to infinity
+        q_sort = np.argsort(self.q)[1:-1]
+        ax.plot(
+            self.q[q_sort],
+            slope * self.all_centers[q_sort] + intercept,
+            color="gray",
+            label=f"Linear fit to flux profile\nm={slope:.1e}, b={intercept:.1e}\nr^2={r_value ** 2:.1e}\n",
+        )
+        if self.slope_overcorrected:
+            log.warning(
+                "Flux profile appears to be overcorrected! In other words, the flux profile appears higher near the "
+                "target than the basis. "
+                "This suggests restarting may have driven the system past its true steady-state. "
+                "This WE run should be continued without restarting, and allowed to relax. "
+            )
+
+            ax.text(
+                0.5,
+                -0.175,
+                "WARNING: Possible flux overcorrection! WE should be continued without restarting now.",
+                ha="center",
+                va="center",
+                transform=ax.transAxes,
+                weight="bold",
+            )
+
         if own_ax:
             ax.legend(bbox_to_anchor=(1.01, 1.0), loc="upper left")
             fig.tight_layout()
@@ -338,6 +367,39 @@ class PlottingMixin:
                 "<",
                 label=f"{_label} flux toward source/basis",
                 **plot_args,
+            )
+
+        # Plot linear fit
+        slope = self.fit_parameters["slope"]
+        intercept = self.fit_parameters["intercept"]
+        r_value = self.fit_parameters["r_value"]
+        # Don't plot first and last points -- for bins spanning to infinity, these might be weird.
+        log.critical(
+            f"Doing linear fit from {self.sorted_centers[:10]} to {self.sorted_centers[-10:]}"
+        )
+        ax.plot(
+            self.all_centers[self.sorted_centers],
+            slope * self.all_centers[self.sorted_centers] + intercept,
+            color="gray",
+            label=f"Linear fit (m={slope:.1e}, b={intercept:.1e}, r^2={r_value ** 2:.1e})",
+        )
+
+        if self.slope_overcorrected:
+            log.warning(
+                "Flux profile appears to be overcorrected! In other words, the flux profile appears higher near the "
+                "target than the basis. "
+                "This suggests restarting may have driven the system past its true steady-state. "
+                "This WE run should be continued without restarting, and allowed to relax. "
+            )
+
+            ax.text(
+                0.5,
+                -0.175,
+                "WARNING: Possible flux overcorrection! WE should be continued without restarting now.",
+                ha="center",
+                va="center",
+                transform=ax.transAxes,
+                weight="bold",
             )
 
         ax.set_yscale("log")

--- a/msm_we/_hamsm/_plotting.py
+++ b/msm_we/_hamsm/_plotting.py
@@ -228,7 +228,7 @@ class PlottingMixin:
 
             ax.text(
                 0.5,
-                -0.175,
+                -0.25,
                 "WARNING: Possible flux overcorrection! WE should be continued without restarting now.",
                 ha="center",
                 va="center",
@@ -374,7 +374,7 @@ class PlottingMixin:
         intercept = self.fit_parameters["intercept"]
         r_value = self.fit_parameters["r_value"]
         # Don't plot first and last points -- for bins spanning to infinity, these might be weird.
-        log.critical(
+        log.debug(
             f"Doing linear fit from {self.sorted_centers[:10]} to {self.sorted_centers[-10:]}"
         )
         ax.plot(
@@ -394,7 +394,7 @@ class PlottingMixin:
 
             ax.text(
                 0.5,
-                -0.175,
+                -0.25,
                 "WARNING: Possible flux overcorrection! WE should be continued without restarting now.",
                 ha="center",
                 va="center",

--- a/msm_we/westpa_plugins/restart_driver.py
+++ b/msm_we/westpa_plugins/restart_driver.py
@@ -392,10 +392,13 @@ class RestartDriver(HAMSMDriver):
         flux_pcoord_fig, flux_pcoord_ax = plt.subplots()
         model.plot_flux(ax=flux_pcoord_ax, suppress_validation=True)
         flux_pcoord_fig.text(
-            x=0.1,
-            y=-0.05,
+            x=0.5,
+            y=-0.15,
+            ha="center",
+            va="center",
             s="This flux profile should become flatter after restarting",
             fontsize=12,
+            transform=flux_pcoord_ax.transAxes,
         )
         flux_pcoord_ax.legend(bbox_to_anchor=(1.01, 1.0), loc="upper left")
         flux_pcoord_fig.savefig(
@@ -405,12 +408,15 @@ class RestartDriver(HAMSMDriver):
         flux_pseudocomm_fig, flux_pseudocomm_ax = plt.subplots()
         model.plot_flux_committor(ax=flux_pseudocomm_ax, suppress_validation=True)
         flux_pseudocomm_fig.text(
-            x=0.1,
-            y=-0.05,
+            x=0.5,
+            y=-0.15,
+            ha="center",
+            va="center",
             s="This flux profile should become flatter after restarting."
             '\nThe x-axis is a "pseudo"committor, since it may be '
             "calculated from WE trajectories in the one-way ensemble.",
             fontsize=12,
+            transform=flux_pseudocomm_ax.transAxes,
         )
         flux_pseudocomm_ax.legend(bbox_to_anchor=(1.01, 1.0), loc="upper left")
         flux_pseudocomm_fig.savefig(


### PR DESCRIPTION
Sometimes, it appears that repeated restarting from poor models can drive the system to a higher-flux steady state

One heuristic for detecting this is "overccorrection" in the flux profiles -- i.e., it should start out higher near the source, and lower near the target, and flatten out. But, when these "bad restarts" happen, it seems to consistently drive the flux profile past flat, to higher near the target, and lower near the source.

We can detect this by doing a curve fit, and looking for when the slope is "wrong" in that way