### PR TITLE
Fixes to mamba env building in Actions

### DIFF
--- a/.github/workflows/mamba-test.yml
+++ b/.github/workflows/mamba-test.yml
@@ -27,13 +27,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
         experimental: [false]
         include:
           - python-version: "3.7"
             experimental: true
-          #- python-version: "3.10"
-          #  experimental: true
+          - python-version: "3.11"
+            experimental: true
     continue-on-error: ${{ matrix.experimental }}
 
     steps:

--- a/.github/workflows/mamba-test.yml
+++ b/.github/workflows/mamba-test.yml
@@ -37,7 +37,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 2
 

--- a/.github/workflows/mamba-test.yml
+++ b/.github/workflows/mamba-test.yml
@@ -52,6 +52,7 @@ jobs:
       uses: mamba-org/provision-with-micromamba@main
       with:
         cache-env: true
+        cache-downloads: true
         environment-file: environment.yml
         extra-specs: |
           python=${{ matrix.python-version }}

--- a/.github/workflows/mamba-test.yml
+++ b/.github/workflows/mamba-test.yml
@@ -23,7 +23,7 @@ jobs:
   test:
     name: Test on Linux, Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest 
-    timeout-minutes: 10
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -52,7 +52,7 @@ jobs:
       uses: mamba-org/provision-with-micromamba@main
       with:
         cache-env: true
-        cache-downloads: true
+        #cache-downloads: true
         environment-file: environment.yml
         extra-specs: |
           python=${{ matrix.python-version }}

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
  - numpy<1.24
  - networkx
- - h5py<3.2
+ - h5py
  - matplotlib
  - mdtraj
  - pyemma


### PR DESCRIPTION
Right now, my Python 3.8 test is failing because it's timing out building the mamba environment. 3.7 and 3.9 are passing because they are using cached environments, which succeeded (at some point in the past)

Additionally,  tests for Python 3.10 and 3.11 were added